### PR TITLE
Lockscreen PIN quick unlock [2/2]

### DIFF
--- a/res/values/validus_strings.xml
+++ b/res/values/validus_strings.xml
@@ -260,4 +260,8 @@
     <!-- Gesture Settings -->
     <!-- Summary text for double twist for camera mode  [CHAR LIMIT=160]-->
     <string name="double_twist_for_camera_mode_custom_summary">To switch in and out of selfie mode in Google Camera, double-twist when you’re in the app</string>
+
+    <!-- Quick unlock -->
+    <string name="unlock_quick_unlock_control_title">Quick unlock</string>
+    <string name="unlock_quick_unlock_control_summary">Unlock automatically when the correct PIN is entered\nNote: will only work for 4 digit PIN !</string>
 </resources>

--- a/res/xml/security_settings_pin.xml
+++ b/res/xml/security_settings_pin.xml
@@ -33,6 +33,12 @@
             android:title="@string/unlock_scramble_pin_layout_title"
             android:summary="@string/unlock_scramble_pin_layout_summary" />
 
+        <SwitchPreference
+            android:key="quick_unlock_control"
+            android:title="@string/unlock_quick_unlock_control_title"
+            android:summary="@string/unlock_quick_unlock_control_summary"
+            android:persistent="false"/>
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/src/com/android/settings/SecuritySettings.java
+++ b/src/com/android/settings/SecuritySettings.java
@@ -91,6 +91,7 @@ public class SecuritySettings extends SettingsPreferenceFragment
     private static final String KEY_ADVANCED_SECURITY = "advanced_security";
     private static final String KEY_MANAGE_TRUST_AGENTS = "manage_trust_agents";
     private static final String KEY_UNIFICATION = "unification";
+    private static final String KEY_LOCKSCREEN_QUICK_UNLOCK_CONTROL = "quick_unlock_control";
 
     private static final int SET_OR_CHANGE_LOCK_METHOD_REQUEST = 123;
     private static final int CHANGE_TRUST_AGENT_SETTINGS = 126;
@@ -116,7 +117,7 @@ public class SecuritySettings extends SettingsPreferenceFragment
     // These switch preferences need special handling since they're not all stored in Settings.
     private static final String SWITCH_PREFERENCE_KEYS[] = {
             KEY_SHOW_PASSWORD, KEY_TOGGLE_INSTALL_APPLICATIONS, KEY_UNIFICATION,
-            KEY_VISIBLE_PATTERN_PROFILE
+            KEY_VISIBLE_PATTERN_PROFILE, KEY_LOCKSCREEN_QUICK_UNLOCK_CONTROL
     };
 
     // Only allow one trust agent on the platform.
@@ -142,6 +143,7 @@ public class SecuritySettings extends SettingsPreferenceFragment
 
     private RestrictedSwitchPreference mToggleAppInstallation;
     private DialogInterface mWarnInstallApps;
+    private SwitchPreference mQuickUnlockScreen;
 
     private boolean mIsAdmin;
 
@@ -296,6 +298,14 @@ public class SecuritySettings extends SettingsPreferenceFragment
         mVisiblePatternProfile =
                 (SwitchPreference) root.findPreference(KEY_VISIBLE_PATTERN_PROFILE);
         mUnifyProfile = (SwitchPreference) root.findPreference(KEY_UNIFICATION);
+
+        // Quick Unlock Screen Control
+        mQuickUnlockScreen = (SwitchPreference) root
+                .findPreference(KEY_LOCKSCREEN_QUICK_UNLOCK_CONTROL);
+        if (mQuickUnlockScreen != null) {
+            mQuickUnlockScreen.setChecked(Settings.Secure.getInt(getContentResolver(),
+                    Settings.Secure.LOCKSCREEN_QUICK_UNLOCK_CONTROL, 0) == 1);
+        }
 
         // Append the rest of the settings
         addPreferencesFromResource(R.xml.security_settings_misc);
@@ -792,6 +802,10 @@ public class SecuritySettings extends SettingsPreferenceFragment
             } else {
                 setNonMarketAppsAllowed(false);
             }
+        } else if (KEY_LOCKSCREEN_QUICK_UNLOCK_CONTROL.equals(key)) {
+            Settings.Secure.putInt(getActivity().getApplicationContext().getContentResolver(),
+                    Settings.Secure.LOCKSCREEN_QUICK_UNLOCK_CONTROL,
+                    (Boolean) value ? 1 : 0);
         }
         return result;
     }


### PR DESCRIPTION
old way does not work anymore exactly like before. So adapt the idea to new LP code

Thankd DVTonder for the basic idea prior LP

Initial LP implementation by Lars Greiss, ported and adapted to MM by Yank555.lu

Disabled by default / only for PIN (not password, pointless)