### PR TITLE
Move the Cast option out of rotation settings

### DIFF
--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -66,6 +66,12 @@
                 android:title="@string/screensaver_settings_title"
                 android:fragment="com.android.settings.DreamSettings" />
 
+        <PreferenceScreen
+                android:key="wifi_display"
+                android:title="@string/wifi_display_settings_title"
+                settings:keywords="@string/keywords_display_cast_screen"
+                android:fragment="com.android.settings.wfd.WifiDisplaySettings" />
+
         <SwitchPreference
                 android:key="tap_to_wake"
                 android:title="@string/tap_to_wake"
@@ -126,12 +132,6 @@
                 android:persistent="false" />
 
         </PreferenceCategory>
-
-        <PreferenceScreen
-                android:key="wifi_display"
-                android:title="@string/wifi_display_settings_title"
-                settings:keywords="@string/keywords_display_cast_screen"
-                android:fragment="com.android.settings.wfd.WifiDisplaySettings" />
 
         <DropDownPreference
                 android:key="vr_display_pref"


### PR DESCRIPTION
 * I overlooked this on my last cleanup commit. Remove the screen cast
 option from the rotation category and put it under screensaver settings.

Signed-off-by: Raleigh Matlock <raleighman2@gmail.com>